### PR TITLE
Qr code filename fix for downloading

### DIFF
--- a/templates/clients.html
+++ b/templates/clients.html
@@ -70,7 +70,9 @@ Wireguard Clients
             </div>
             <div class="modal-body">
                 <input type="hidden" id="qr_client_id" name="qr_client_id">
-                <img id="qr_code" class="w-100" style="image-rendering: pixelated;" src="" alt="QR code" />
+                <a href="" download="" id="qr_code_a">
+                    <img id="qr_code" class="w-100" style="image-rendering: pixelated;" src="" alt="QR code" />
+                </a>
                 <div class="form-group">
                     <div class="icheck-primary d-inline">
                         <input type="checkbox" id="qr_include_fwmark" onchange="regenerateQRCode()">
@@ -391,6 +393,7 @@ Wireguard Clients
         function regenerateQRCode() {
             const client_id = $("#qr_client_id").val();
             const QRCodeImg = $("#qr_code");
+            const QRCodeA = $("#qr_code_a");
             let include_fwmark = false;
             if ($("#qr_include_fwmark").is(':checked')){
                 include_fwmark = true;
@@ -410,6 +413,9 @@ Wireguard Clients
 
                     $(".modal-title").text("Scan QR Code for " + client.name + " profile");
                     QRCodeImg.attr('src', resp.QRCode).show();
+                    QRCodeA.attr('download', resp.Client.name);
+                    QRCodeA.attr('href', resp.QRCode).show();
+
                 },
                 error: function (jqXHR, exception) {
                     const responseJson = jQuery.parseJSON(jqXHR.responseText);


### PR DESCRIPTION
When downloading QR code, the filename will be Client name, instead of generic. Ability to left click on QR code to download it.